### PR TITLE
Upgraded Dropwizard to 4.0.1 and CoreNLP to 4.5.4 (#14)

### DIFF
--- a/nlp-service/dependencies.txt
+++ b/nlp-service/dependencies.txt
@@ -1,169 +1,183 @@
 
 The following files have been resolved:
-   org.slf4j:jcl-over-slf4j:jar:1.7.36:runtime
-   io.dropwizard.metrics:metrics-jvm:jar:4.1.36:compile
    javax.xml.bind:jaxb-api:jar:2.4.0-b180830.0359:compile
    org.jvnet.mimepull:mimepull:jar:1.9.13:compile
    net.jcip:jcip-annotations:jar:1.0:provided
-   io.dropwizard:dropwizard-util:jar:2.0.35:compile
-   org.glassfish.hk2:hk2-locator:jar:2.6.1:runtime
-   org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
-   org.eclipse.jetty:jetty-webapp:jar:9.4.50.v20221201:compile
-   org.glassfish.hk2:hk2-utils:jar:2.6.1:compile
+   io.swagger.core.v3:swagger-core-jakarta:jar:2.2.9:compile
    org.ejml:ejml-cdense:jar:0.39:compile
-   org.mockito:mockito-core:jar:4.11.0:test
-   io.dropwizard:dropwizard-assets:jar:2.0.35:compile
+   io.dropwizard:dropwizard-util:jar:4.0.1:compile
+   io.dropwizard.metrics:metrics-caffeine:jar:4.2.19:compile
+   org.junit.jupiter:junit-jupiter-params:jar:5.9.3:test
+   io.swagger.core.v3:swagger-annotations:jar:2.2.9:compile
+   org.glassfish.jersey.media:jersey-media-json-jackson:jar:3.0.10:compile
    org.glassfish:javax.json:jar:1.0.4:compile
+   com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.2:compile
+   org.opentest4j:opentest4j:jar:1.2.0:test
    org.apache.commons:commons-lang3:jar:3.12.0:compile
-   com.google.j2objc:j2objc-annotations:jar:1.3:compile
+   org.glassfish.jersey.ext:jersey-bean-validation:jar:3.0.10:compile
    xml-apis:xml-apis:jar:1.4.01:compile
-   io.dropwizard:dropwizard-views-freemarker:jar:2.0.35:compile
-   jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
-   com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.10.5:compile
    com.googlecode.json-simple:json-simple:jar:1.1.1:compile
-   org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:compile
-   io.dropwizard:dropwizard-servlets:jar:2.0.35:compile
-   org.glassfish.jersey.containers:jersey-container-servlet:jar:2.33:runtime
-   jakarta.servlet:jakarta.servlet-api:jar:4.0.4:compile
+   org.glassfish:jakarta.el:jar:4.0.2:compile
+   com.beust:jcommander:jar:1.82:test
+   io.dropwizard:dropwizard-servlets:jar:4.0.1:compile
+   org.eclipse.jetty:jetty-webapp:jar:11.0.15:compile
    commons-codec:commons-codec:jar:1.15:compile
-   org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.33:test
-   org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
+   org.junit.jupiter:junit-jupiter-api:jar:5.9.3:test
+   com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.15.2:compile
    javax.servlet:javax.servlet-api:jar:3.0.1:compile
-   io.dropwizard.metrics:metrics-caffeine:jar:4.1.36:compile
+   org.glassfish.hk2:hk2-api:jar:3.0.4:compile
    xalan:serializer:jar:2.7.2:compile
+   io.dropwizard:dropwizard-health:jar:4.0.1:compile
+   com.google.code.findbugs:jsr305:jar:3.0.1:compile
    com.sun.xml.bind:jaxb-impl:jar:2.4.0-b180830.0438:compile
-   io.dropwizard:dropwizard-metrics:jar:2.0.35:compile
+   jakarta.servlet:jakarta.servlet-api:jar:5.0.0:compile
+   org.junit.jupiter:junit-jupiter-engine:jar:5.9.3:test
    javax.activation:javax.activation-api:jar:1.2.0:compile
-   org.eclipse.jetty:jetty-security:jar:9.4.50.v20221201:compile
+   org.apache.httpcomponents.core5:httpcore5:jar:5.2.1:test
+   commons-logging:commons-logging:jar:1.2:compile
    xalan:xalan:jar:2.7.2:compile
    org.javassist:javassist:jar:3.29.2-GA:compile
-   com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.10.5:compile
-   io.dropwizard:dropwizard-request-logging:jar:2.0.35:compile
-   org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.33:compile
+   net.sourceforge.argparse4j:argparse4j:jar:0.9.0:compile
+   org.glassfish.jersey.core:jersey-server:jar:3.0.10:compile
    de.jollyday:jollyday:jar:0.4.9:compile
-   com.smoketurner:dropwizard-swagger:jar:2.0.0-1:compile
-   javax.validation:validation-api:jar:1.1.0.Final:compile
-   jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:runtime
+   io.dropwizard:dropwizard-views-freemarker:jar:4.0.1:compile
+   net.bytebuddy:byte-buddy:jar:1.14.5:test
+   com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.2:compile
    org.apache.lucene:lucene-core:jar:7.5.0:compile
-   org.glassfish.jersey.ext:jersey-bean-validation:jar:2.33:compile
    org.apache.commons:commons-text:jar:1.10.0:compile
-   com.google.guava:guava:jar:31.1-jre:compile
-   org.eclipse.jetty:jetty-util-ajax:jar:9.4.50.v20221201:compile
-   com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.10.5:compile
+   org.yaml:snakeyaml:jar:2.0:compile
+   org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.4:compile
    com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
    org.ejml:ejml-zdense:jar:0.39:compile
-   io.dropwizard:dropwizard-core:jar:2.0.35:compile
-   edu.stanford.nlp:stanford-corenlp:jar:models:4.5.3:compile
-   io.swagger:swagger-annotations:jar:1.6.0:compile
-   commons-io:commons-io:jar:2.11.0:compile
-   com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:compile
-   org.eclipse.jetty:jetty-servlet:jar:9.4.50.v20221201:compile
-   io.dropwizard.metrics:metrics-logback:jar:4.1.36:compile
+   io.dropwizard:dropwizard-core:jar:4.0.1:compile
+   net.bytebuddy:byte-buddy-agent:jar:1.14.1:test
+   org.glassfish.hk2:hk2-utils:jar:3.0.4:compile
+   org.apache.httpcomponents.client5:httpclient5:jar:5.2.1:test
+   org.eclipse.jetty:jetty-servlet:jar:11.0.15:compile
+   io.dropwizard.metrics:metrics-jakarta-servlets:jar:4.2.19:compile
+   com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.15.2:compile
+   joda-time:joda-time:jar:2.10.5:compile
+   com.fasterxml.jackson.core:jackson-core:jar:2.15.2:compile
+   io.dropwizard.logback:logback-throttling-appender:jar:1.4.0:compile
+   org.glassfish.jersey.inject:jersey-hk2:jar:3.0.10:runtime
+   org.glassfish.jersey.core:jersey-common:jar:3.0.10:compile
+   com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.15.2:compile
+   org.glassfish.jersey.ext:jersey-metainf-services:jar:3.0.10:runtime
    org.assertj:assertj-core:jar:3.24.2:test
-   io.dropwizard.metrics:metrics-servlets:jar:4.1.36:compile
-   com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.10.5:compile
-   com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.10.5:compile
-   com.google.errorprone:error_prone_annotations:jar:2.10.0:compile
-   io.dropwizard:dropwizard-views:jar:2.0.35:compile
+   io.dropwizard:dropwizard-lifecycle:jar:4.0.1:compile
+   io.dropwizard.metrics:metrics-jvm:jar:4.2.19:compile
+   io.dropwizard.metrics:metrics-annotation:jar:4.2.19:compile
+   jakarta.activation:jakarta.activation-api:jar:2.0.1:runtime
+   org.hamcrest:hamcrest:jar:2.2:test
+   io.dropwizard:dropwizard-logging:jar:4.0.1:compile
+   org.glassfish.jersey.containers:jersey-container-servlet-core:jar:3.0.10:compile
    org.ejml:ejml-dsparse:jar:0.39:compile
-   io.dropwizard.metrics:metrics-core:jar:4.1.36:compile
-   io.dropwizard.metrics:metrics-json:jar:4.1.36:compile
    xerces:xercesImpl:jar:2.12.2:compile
+   io.dropwizard:dropwizard-metrics:jar:4.0.1:compile
+   io.dropwizard.metrics:metrics-jersey3:jar:4.2.19:compile
    org.apache.lucene:lucene-analyzers-common:jar:7.5.0:compile
-   io.dropwizard.metrics:metrics-jersey2:jar:4.1.36:compile
-   io.dropwizard:dropwizard-jetty:jar:2.0.35:compile
-   jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
-   org.eclipse.jetty:jetty-http:jar:9.4.50.v20221201:compile
-   com.beust:jcommander:jar:1.78:test
+   com.smoketurner:dropwizard-swagger:jar:4.0.0-1:compile
+   commons-io:commons-io:jar:2.13.0:compile
+   com.sun.activation:jakarta.activation:jar:2.0.1:compile
    org.apache.httpcomponents:httpclient:jar:4.5.14:compile
-   net.sourceforge.argparse4j:argparse4j:jar:0.8.1:compile
-   org.glassfish.jersey.media:jersey-media-multipart:jar:2.33:compile
    org.ejml:ejml-ddense:jar:0.39:compile
    org.ejml:ejml-fsparse:jar:0.39:compile
-   org.reflections:reflections:jar:0.9.11:compile
-   org.eclipse.jetty:jetty-servlets:jar:9.4.50.v20221201:compile
-   org.yaml:snakeyaml:jar:1.33:compile
-   org.glassfish.jersey.core:jersey-client:jar:2.33:compile
-   io.swagger:swagger-jersey2-jaxrs:jar:1.6.0:compile
+   io.dropwizard:dropwizard-configuration:jar:4.0.1:compile
+   io.github.classgraph:classgraph:jar:4.8.154:compile
+   io.swagger.core.v3:swagger-annotations-jakarta:jar:2.2.9:compile
    org.ejml:ejml-simple:jar:0.39:compile
    com.fasterxml:classmate:jar:1.5.1:compile
+   org.hamcrest:hamcrest-core:jar:1.1:compile
+   org.eclipse.jetty:jetty-security:jar:11.0.15:compile
    org.apache.lucene:lucene-queries:jar:7.5.0:compile
-   org.hibernate.validator:hibernate-validator:jar:6.1.7.Final:compile
-   org.glassfish.jersey.inject:jersey-hk2:jar:2.33:runtime
-   io.dropwizard:dropwizard-jackson:jar:2.0.35:compile
-   org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.33:compile
+   org.eclipse.jetty:jetty-server:jar:11.0.15:compile
+   io.dropwizard:dropwizard-jackson:jar:4.0.1:compile
+   io.dropwizard:dropwizard-testing:jar:4.0.1:test
+   jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
+   org.glassfish.jersey.core:jersey-client:jar:3.0.10:compile
+   io.dropwizard:dropwizard-jersey:jar:4.0.1:compile
+   io.swagger.core.v3:swagger-jaxrs2-jakarta:jar:2.2.9:compile
+   org.eclipse.jetty:jetty-xml:jar:11.0.15:compile
    com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
-   io.dropwizard:dropwizard-jersey:jar:2.0.35:compile
-   joda-time:joda-time:jar:2.12.2:compile
-   io.dropwizard.metrics:metrics-jmx:jar:4.1.36:compile
    org.freemarker:freemarker:jar:2.3.32:compile
-   ch.qos.logback:logback-access:jar:1.2.11:compile
-   io.swagger.core.v3:swagger-annotations:jar:2.1.12:compile
-   org.glassfish.jersey.media:jersey-media-jaxb:jar:2.33:test
    org.objenesis:objenesis:jar:3.3:test
-   org.slf4j:slf4j-api:jar:1.7.36:compile
-   org.glassfish.hk2:hk2-api:jar:2.6.1:compile
-   jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
-   org.glassfish.jersey.core:jersey-server:jar:2.33:compile
+   org.slf4j:jul-to-slf4j:jar:2.0.7:compile
+   io.dropwizard.metrics:metrics-healthchecks:jar:4.2.19:compile
+   org.eclipse.jetty:jetty-io:jar:11.0.15:compile
    org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
-   jakarta.activation:jakarta.activation-api:jar:1.2.2:runtime
-   io.dropwizard.metrics:metrics-healthchecks:jar:4.1.36:compile
-   ch.qos.logback:logback-core:jar:1.2.11:compile
+   org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:jar:5.0.2:compile
+   org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:3.0.10:test
+   ch.qos.logback:logback-classic:jar:1.4.8:compile
+   io.swagger.core.v3:swagger-models-jakarta:jar:2.2.9:compile
    com.google.guava:failureaccess:jar:1.0.1:compile
-   junit:junit:jar:4.13.2:compile
-   com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
-   org.hamcrest:hamcrest-core:jar:1.3:compile
+   com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.15.2:compile
+   io.dropwizard:dropwizard-validation:jar:4.0.1:compile
+   ch.qos.logback:logback-access:jar:1.4.8:compile
+   com.google.errorprone:error_prone_annotations:jar:2.20.0:compile
+   io.dropwizard.metrics:metrics-jmx:jar:4.2.19:compile
    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
-   io.dropwizard:dropwizard-validation:jar:2.0.35:compile
+   org.eclipse.jetty:jetty-servlets:jar:11.0.15:compile
+   edu.stanford.nlp:stanford-corenlp:jar:models:4.5.4:compile
+   org.eclipse.jetty:jetty-http:jar:11.0.15:compile
+   io.dropwizard:dropwizard-views:jar:4.0.1:compile
    org.ejml:ejml-fdense:jar:0.39:compile
    org.apache.lucene:lucene-sandbox:jar:7.5.0:compile
+   org.junit.platform:junit-platform-engine:jar:1.9.3:test
    com.apple:AppleJavaExtensions:jar:1.4:compile
-   net.bytebuddy:byte-buddy:jar:1.12.22:test
-   io.dropwizard.logback:logback-throttling-appender:jar:1.1.9:compile
-   ch.qos.logback:logback-classic:jar:1.2.11:compile
-   org.glassfish.jersey.ext:jersey-entity-filtering:jar:2.33:compile
-   io.swagger:swagger-core:jar:1.6.0:compile
-   org.glassfish:jakarta.el:jar:3.0.4:compile
-   io.dropwizard:dropwizard-auth:jar:2.0.35:compile
-   io.dropwizard:dropwizard-testing:jar:2.0.35:test
-   org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:2.33:test
-   org.glassfish.jersey.media:jersey-media-json-jackson:jar:2.33:compile
-   com.google.code.findbugs:jsr305:jar:3.0.2:compile
-   io.swagger:swagger-jaxrs:jar:1.6.0:compile
-   com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
+   org.slf4j:jcl-over-slf4j:jar:2.0.7:runtime
+   org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2:test
+   org.glassfish.jersey.connectors:jersey-apache-connector:jar:3.0.10:compile
+   junit:junit:jar:4.10:compile
+   io.dropwizard.metrics:metrics-jetty11:jar:4.2.19:compile
+   org.checkerframework:checker-qual:jar:3.35.0:compile
+   org.slf4j:log4j-over-slf4j:jar:2.0.7:runtime
+   org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:3.0.10:test
+   jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
+   org.jboss.logging:jboss-logging:jar:3.5.1.Final:compile
+   org.mockito:mockito-testng:jar:0.5.0:test
+   com.google.guava:guava:jar:32.0.1-jre:compile
+   org.slf4j:slf4j-api:jar:2.0.7:compile
+   com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.15.2:compile
+   io.dropwizard.metrics:metrics-core:jar:4.2.19:compile
+   com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.2:compile
+   io.dropwizard:dropwizard-auth:jar:4.0.1:compile
+   org.glassfish.jersey.media:jersey-media-jaxb:jar:3.0.10:test
+   org.glassfish.jersey.media:jersey-media-multipart:jar:3.0.10:compile
+   jakarta.el:jakarta.el-api:jar:4.0.0:compile
    xom:xom:jar:1.3.8:compile
-   org.testng:testng:jar:7.5:test
+   io.dropwizard.metrics:metrics-json:jar:4.2.19:compile
+   org.mockito:mockito-core:jar:5.2.0:test
+   org.glassfish.hk2:hk2-locator:jar:3.0.4:runtime
    com.google.code.findbugs:annotations:jar:3.0.1u2:provided
-   org.eclipse.jetty:jetty-util:jar:9.4.50.v20221201:compile
-   net.bytebuddy:byte-buddy-agent:jar:1.12.19:test
+   io.dropwizard:dropwizard-request-logging:jar:4.0.1:compile
+   com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.15.2:compile
+   org.junit.platform:junit-platform-commons:jar:1.9.3:test
+   com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
    org.ejml:ejml-core:jar:0.39:compile
-   io.dropwizard.metrics:metrics-annotation:jar:4.1.36:compile
-   com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.10.5:compile
-   io.dropwizard.metrics:metrics-jetty9:jar:4.1.36:compile
-   org.eclipse.jetty:jetty-io:jar:9.4.50.v20221201:compile
-   io.dropwizard:dropwizard-configuration:jar:2.0.35:compile
-   org.slf4j:jul-to-slf4j:jar:1.7.36:compile
-   org.webjars:jquery:jar:3.5.1:test
-   org.mockito:mockito-testng:jar:0.4.31:test
-   org.eclipse.jetty:jetty-continuation:jar:9.4.50.v20221201:compile
-   com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.10.5:compile
-   org.eclipse.jetty:jetty-server:jar:9.4.50.v20221201:compile
-   io.dropwizard:dropwizard-logging:jar:2.0.35:compile
+   edu.stanford.nlp:stanford-corenlp:jar:4.5.4:compile
+   jakarta.annotation:jakarta.annotation-api:jar:2.0.0:compile
+   org.eclipse.jetty:jetty-util:jar:11.0.15:compile
+   org.glassfish.jersey.ext:jersey-entity-filtering:jar:3.0.10:compile
+   ch.qos.logback:logback-core:jar:1.4.8:compile
+   org.glassfish.jersey.containers:jersey-container-servlet:jar:3.0.10:runtime
+   org.junit.jupiter:junit-jupiter:jar:5.9.3:test
+   io.swagger.core.v3:swagger-integration-jakarta:jar:2.2.9:compile
+   com.google.j2objc:j2objc-annotations:jar:2.8:compile
+   jakarta.ws.rs:jakarta.ws.rs-api:jar:3.0.0:compile
    com.helger:profiler:jar:1.1.1:compile
-   org.eclipse.jetty:jetty-xml:jar:9.4.50.v20221201:compile
    org.apache.commons:commons-collections4:jar:4.4:compile
-   org.slf4j:log4j-over-slf4j:jar:1.7.36:runtime
    org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.4:compile
-   com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.10.5:compile
-   org.glassfish.jersey.ext:jersey-metainf-services:jar:2.33:runtime
-   org.glassfish.jersey.core:jersey-common:jar:2.33:compile
+   io.dropwizard.metrics:metrics-logback:jar:4.2.19:compile
+   io.dropwizard:dropwizard-jetty:jar:4.0.1:compile
+   com.github.ben-manes.caffeine:caffeine:jar:3.1.6:compile
+   org.apiguardian:apiguardian-api:jar:1.1.2:test
+   org.testng:testng:jar:7.8.0:test
+   org.hibernate.validator:hibernate-validator:jar:7.0.5.Final:compile
+   com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
    com.google.protobuf:protobuf-java:jar:3.19.6:compile
-   org.checkerframework:checker-qual:jar:3.29.0:compile
-   com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.10.5:compile
-   edu.stanford.nlp:stanford-corenlp:jar:4.5.3:compile
-   com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.5:compile
-   io.swagger:swagger-models:jar:1.6.0:compile
+   jakarta.inject:jakarta.inject-api:jar:2.0.1.MR:compile
+   org.glassfish.jersey.connectors:jersey-apache5-connector:jar:3.0.10:test
+   org.webjars:jquery:jar:3.6.1:test
    org.apache.lucene:lucene-queryparser:jar:7.5.0:compile
-   io.dropwizard:dropwizard-lifecycle:jar:2.0.35:compile
-   com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile
+   io.dropwizard:dropwizard-assets:jar:4.0.1:compile
 

--- a/nlp-service/dependencies_tree.txt
+++ b/nlp-service/dependencies_tree.txt
@@ -1,5 +1,5 @@
-com.veritas.nlp:nlp-service:jar:0.1.11-SNAPSHOT
-+- edu.stanford.nlp:stanford-corenlp:jar:4.5.3:compile
+com.veritas.nlp:nlp-service:jar:0.1.12-SNAPSHOT
++- edu.stanford.nlp:stanford-corenlp:jar:4.5.4:compile
 |  +- com.apple:AppleJavaExtensions:jar:1.4:compile
 |  +- de.jollyday:jollyday:jar:0.4.9:compile
 |  +- org.apache.lucene:lucene-queryparser:jar:7.5.0:compile
@@ -11,7 +11,7 @@ com.veritas.nlp:nlp-service:jar:0.1.11-SNAPSHOT
 |  +- xom:xom:jar:1.3.8:compile
 |  |  \- xalan:xalan:jar:2.7.2:compile
 |  |     \- xalan:serializer:jar:2.7.2:compile
-|  +- joda-time:joda-time:jar:2.12.2:compile
+|  +- joda-time:joda-time:jar:2.10.5:compile
 |  +- org.ejml:ejml-core:jar:0.39:compile
 |  +- org.ejml:ejml-ddense:jar:0.39:compile
 |  +- org.ejml:ejml-simple:jar:0.39:compile
@@ -21,147 +21,161 @@ com.veritas.nlp:nlp-service:jar:0.1.11-SNAPSHOT
 |  |  +- org.ejml:ejml-dsparse:jar:0.39:compile
 |  |  \- org.ejml:ejml-fsparse:jar:0.39:compile
 |  +- org.glassfish:javax.json:jar:1.0.4:compile
-|  +- org.slf4j:slf4j-api:jar:1.7.36:compile
+|  +- org.slf4j:slf4j-api:jar:2.0.7:compile
 |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
 |  +- javax.activation:javax.activation-api:jar:1.2.0:compile
 |  +- javax.xml.bind:jaxb-api:jar:2.4.0-b180830.0359:compile
 |  +- com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
 |  +- com.sun.xml.bind:jaxb-impl:jar:2.4.0-b180830.0438:compile
 |  \- com.googlecode.json-simple:json-simple:jar:1.1.1:compile
-|     \- junit:junit:jar:4.13.2:compile
-|        \- org.hamcrest:hamcrest-core:jar:1.3:compile
-+- edu.stanford.nlp:stanford-corenlp:jar:models:4.5.3:compile
-+- io.dropwizard:dropwizard-core:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-util:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-jackson:jar:2.0.35:compile
-|  |  +- com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile
-|  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.10.5:compile
-|  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.10.5:compile
-|  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.10.5:compile
-|  |  +- com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.10.5:compile
-|  |  \- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.10.5:compile
-|  +- io.dropwizard:dropwizard-validation:jar:2.0.35:compile
+|     \- junit:junit:jar:4.10:compile
+|        \- org.hamcrest:hamcrest-core:jar:1.1:compile
++- edu.stanford.nlp:stanford-corenlp:jar:models:4.5.4:compile
++- io.dropwizard:dropwizard-core:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-util:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-jackson:jar:4.0.1:compile
+|  |  +- com.github.ben-manes.caffeine:caffeine:jar:3.1.6:compile
+|  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.2:compile
+|  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.2:compile
+|  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.15.2:compile
+|  |  \- com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.15.2:compile
+|  +- io.dropwizard:dropwizard-validation:jar:4.0.1:compile
 |  |  +- com.fasterxml:classmate:jar:1.5.1:compile
-|  |  \- org.glassfish:jakarta.el:jar:3.0.4:compile
-|  +- io.dropwizard:dropwizard-configuration:jar:2.0.35:compile
-|  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.10.5:compile
+|  |  \- org.glassfish:jakarta.el:jar:4.0.2:compile
+|  |     \- jakarta.el:jakarta.el-api:jar:4.0.0:compile
+|  +- io.dropwizard:dropwizard-configuration:jar:4.0.1:compile
+|  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.2:compile
 |  |  \- org.apache.commons:commons-text:jar:1.10.0:compile
-|  +- io.dropwizard:dropwizard-logging:jar:2.0.35:compile
-|  |  +- io.dropwizard.metrics:metrics-logback:jar:4.1.36:compile
-|  |  +- org.slf4j:jul-to-slf4j:jar:1.7.36:compile
-|  |  +- ch.qos.logback:logback-core:jar:1.2.11:compile
-|  |  +- io.dropwizard.logback:logback-throttling-appender:jar:1.1.9:compile
-|  |  +- org.slf4j:log4j-over-slf4j:jar:1.7.36:runtime
-|  |  \- org.slf4j:jcl-over-slf4j:jar:1.7.36:runtime
-|  +- io.dropwizard:dropwizard-metrics:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-jersey:jar:2.0.35:compile
-|  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:2.33:runtime
-|  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.33:runtime
-|  |  |  \- org.glassfish.hk2:hk2-locator:jar:2.6.1:runtime
+|  +- io.dropwizard:dropwizard-logging:jar:4.0.1:compile
+|  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.19:compile
+|  |  +- org.slf4j:jul-to-slf4j:jar:2.0.7:compile
+|  |  +- ch.qos.logback:logback-core:jar:1.4.8:compile
+|  |  +- io.dropwizard.logback:logback-throttling-appender:jar:1.4.0:compile
+|  |  +- org.slf4j:log4j-over-slf4j:jar:2.0.7:runtime
+|  |  \- org.slf4j:jcl-over-slf4j:jar:2.0.7:runtime
+|  +- io.dropwizard:dropwizard-metrics:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-jersey:jar:4.0.1:compile
+|  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:3.0.10:runtime
+|  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:3.0.10:runtime
+|  |  |  \- org.glassfish.hk2:hk2-locator:jar:3.0.4:runtime
 |  |  +- org.javassist:javassist:jar:3.29.2-GA:compile
-|  |  +- io.dropwizard.metrics:metrics-jersey2:jar:4.1.36:compile
-|  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
-|  |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:compile
-|  |  |  +- org.glassfish.hk2:hk2-utils:jar:2.6.1:compile
-|  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:compile
-|  |  \- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.33:runtime
-|  +- io.dropwizard:dropwizard-servlets:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-jetty:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-lifecycle:jar:2.0.35:compile
-|  +- io.dropwizard.metrics:metrics-core:jar:4.1.36:compile
-|  +- io.dropwizard.metrics:metrics-jetty9:jar:4.1.36:compile
-|  +- io.dropwizard.metrics:metrics-jvm:jar:4.1.36:compile
-|  +- io.dropwizard.metrics:metrics-jmx:jar:4.1.36:compile
-|  +- io.dropwizard.metrics:metrics-servlets:jar:4.1.36:compile
-|  |  +- io.dropwizard.metrics:metrics-json:jar:4.1.36:compile
+|  |  +- io.dropwizard.metrics:metrics-jersey3:jar:4.2.19:compile
+|  |  +- jakarta.annotation:jakarta.annotation-api:jar:2.0.0:compile
+|  |  +- org.glassfish.hk2:hk2-api:jar:3.0.4:compile
+|  |  |  +- org.glassfish.hk2:hk2-utils:jar:3.0.4:compile
+|  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.4:compile
+|  |  \- org.glassfish.jersey.containers:jersey-container-servlet:jar:3.0.10:runtime
+|  +- io.dropwizard:dropwizard-servlets:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-jetty:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-lifecycle:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-health:jar:4.0.1:compile
+|  +- io.dropwizard.metrics:metrics-core:jar:4.2.19:compile
+|  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.19:compile
+|  +- io.dropwizard.metrics:metrics-jetty11:jar:4.2.19:compile
+|  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.19:compile
+|  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.19:compile
+|  +- io.dropwizard.metrics:metrics-jakarta-servlets:jar:4.2.19:compile
+|  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.19:compile
 |  |  \- com.helger:profiler:jar:1.1.1:compile
-|  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.1.36:compile
-|  +- io.dropwizard:dropwizard-request-logging:jar:2.0.35:compile
-|  |  \- ch.qos.logback:logback-access:jar:1.2.11:compile
-|  +- ch.qos.logback:logback-classic:jar:1.2.11:compile
-|  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
-|  +- jakarta.servlet:jakarta.servlet-api:jar:4.0.4:compile
-|  +- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
-|  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
-|  +- net.sourceforge.argparse4j:argparse4j:jar:0.8.1:compile
-|  +- org.eclipse.jetty:jetty-security:jar:9.4.50.v20221201:compile
-|  +- org.eclipse.jetty:jetty-util:jar:9.4.50.v20221201:compile
+|  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.19:compile
+|  +- io.dropwizard:dropwizard-request-logging:jar:4.0.1:compile
+|  |  \- ch.qos.logback:logback-access:jar:1.4.8:compile
+|  +- ch.qos.logback:logback-classic:jar:1.4.8:compile
+|  +- org.checkerframework:checker-qual:jar:3.35.0:compile
+|  +- jakarta.servlet:jakarta.servlet-api:jar:5.0.0:compile
+|  +- jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
+|  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:3.0.0:compile
+|  +- net.sourceforge.argparse4j:argparse4j:jar:0.9.0:compile
+|  +- org.eclipse.jetty:jetty-security:jar:11.0.15:compile
+|  +- org.eclipse.jetty:jetty-util:jar:11.0.15:compile
 |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.4:compile
-|  +- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
-|  +- org.glassfish.jersey.core:jersey-common:jar:2.33:compile
+|  +- jakarta.inject:jakarta.inject-api:jar:2.0.1.MR:compile
+|  +- org.glassfish.jersey.core:jersey-common:jar:3.0.10:compile
 |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
-|  +- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.33:compile
-|  \- org.hibernate.validator:hibernate-validator:jar:6.1.7.Final:compile
-|     \- org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile
-+- io.dropwizard:dropwizard-testing:jar:2.0.35:test
-|  +- io.dropwizard.metrics:metrics-annotation:jar:4.1.36:compile
-|  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.10.5:compile
-|  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.10.5:compile
-|  |  \- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.5:compile
-|  +- org.eclipse.jetty:jetty-io:jar:9.4.50.v20221201:compile
-|  +- org.glassfish.jersey.core:jersey-server:jar:2.33:compile
-|  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.33:test
-|  |  \- org.glassfish.jersey.media:jersey-media-jaxb:jar:2.33:test
-|  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:2.33:test
-|  +- jakarta.activation:jakarta.activation-api:jar:1.2.2:runtime
-|  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:runtime
-+- com.smoketurner:dropwizard-swagger:jar:2.0.0-1:compile
-|  +- io.dropwizard:dropwizard-auth:jar:2.0.35:compile
-|  |  \- io.dropwizard.metrics:metrics-caffeine:jar:4.1.36:compile
-|  +- io.dropwizard:dropwizard-assets:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-views:jar:2.0.35:compile
-|  +- io.dropwizard:dropwizard-views-freemarker:jar:2.0.35:compile
+|  +- org.glassfish.jersey.ext:jersey-bean-validation:jar:3.0.10:compile
+|  |  \- org.jboss.logging:jboss-logging:jar:3.5.1.Final:compile
+|  \- org.hibernate.validator:hibernate-validator:jar:7.0.5.Final:compile
++- io.dropwizard:dropwizard-testing:jar:4.0.1:test
+|  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.15.2:compile
+|  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.15.2:compile
+|  |  \- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.15.2:compile
+|  +- org.eclipse.jetty:jetty-io:jar:11.0.15:compile
+|  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:3.0.10:test
+|  +- org.apache.httpcomponents.client5:httpclient5:jar:5.2.1:test
+|  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.2.1:test
+|  |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2:test
+|  +- org.glassfish.jersey.core:jersey-server:jar:3.0.10:compile
+|  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:3.0.10:test
+|  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:3.0.10:test
+|  |  +- org.junit.jupiter:junit-jupiter:jar:5.9.3:test
+|  |  |  +- org.junit.jupiter:junit-jupiter-api:jar:5.9.3:test
+|  |  |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
+|  |  |  |  +- org.junit.platform:junit-platform-commons:jar:1.9.3:test
+|  |  |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
+|  |  |  +- org.junit.jupiter:junit-jupiter-params:jar:5.9.3:test
+|  |  |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.9.3:test
+|  |  |     \- org.junit.platform:junit-platform-engine:jar:1.9.3:test
+|  |  \- org.hamcrest:hamcrest:jar:2.2:test
+|  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:3.0.10:test
+|  +- jakarta.activation:jakarta.activation-api:jar:2.0.1:runtime
+|  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
+|     \- com.sun.activation:jakarta.activation:jar:2.0.1:compile
++- com.smoketurner:dropwizard-swagger:jar:4.0.0-1:compile
+|  +- io.dropwizard:dropwizard-auth:jar:4.0.1:compile
+|  |  \- io.dropwizard.metrics:metrics-caffeine:jar:4.2.19:compile
+|  +- io.dropwizard:dropwizard-assets:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-views:jar:4.0.1:compile
+|  +- io.dropwizard:dropwizard-views-freemarker:jar:4.0.1:compile
 |  |  \- org.freemarker:freemarker:jar:2.3.32:compile
-|  \- io.swagger:swagger-jersey2-jaxrs:jar:1.6.0:compile
-|     \- io.swagger:swagger-jaxrs:jar:1.6.0:compile
-|        +- io.swagger:swagger-core:jar:1.6.0:compile
-|        |  +- io.swagger:swagger-models:jar:1.6.0:compile
-|        |  |  \- io.swagger:swagger-annotations:jar:1.6.0:compile
-|        |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
-|        \- org.reflections:reflections:jar:0.9.11:compile
-+- org.eclipse.jetty:jetty-server:jar:9.4.50.v20221201:compile
-|  \- org.eclipse.jetty:jetty-http:jar:9.4.50.v20221201:compile
-+- org.eclipse.jetty:jetty-servlet:jar:9.4.50.v20221201:compile
-|  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.50.v20221201:compile
-+- org.eclipse.jetty:jetty-servlets:jar:9.4.50.v20221201:compile
-|  \- org.eclipse.jetty:jetty-continuation:jar:9.4.50.v20221201:compile
-+- org.eclipse.jetty:jetty-webapp:jar:9.4.50.v20221201:compile
-|  \- org.eclipse.jetty:jetty-xml:jar:9.4.50.v20221201:compile
-+- io.swagger.core.v3:swagger-annotations:jar:2.1.12:compile
+|  +- io.swagger.core.v3:swagger-jaxrs2-jakarta:jar:2.2.9:compile
+|  |  +- io.github.classgraph:classgraph:jar:4.8.154:compile
+|  |  \- io.swagger.core.v3:swagger-models-jakarta:jar:2.2.9:compile
+|  +- io.swagger.core.v3:swagger-annotations-jakarta:jar:2.2.9:compile
+|  \- io.swagger.core.v3:swagger-integration-jakarta:jar:2.2.9:compile
+|     \- io.swagger.core.v3:swagger-core-jakarta:jar:2.2.9:compile
++- org.eclipse.jetty:jetty-server:jar:11.0.15:compile
+|  +- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:jar:5.0.2:compile
+|  \- org.eclipse.jetty:jetty-http:jar:11.0.15:compile
++- org.eclipse.jetty:jetty-servlet:jar:11.0.15:compile
++- org.eclipse.jetty:jetty-servlets:jar:11.0.15:compile
++- org.eclipse.jetty:jetty-webapp:jar:11.0.15:compile
+|  \- org.eclipse.jetty:jetty-xml:jar:11.0.15:compile
++- io.swagger.core.v3:swagger-annotations:jar:2.2.9:compile
 +- org.apache.commons:commons-lang3:jar:3.12.0:compile
 +- org.apache.commons:commons-collections4:jar:4.4:compile
-+- commons-io:commons-io:jar:2.11.0:compile
-+- com.google.guava:guava:jar:31.1-jre:compile
++- commons-io:commons-io:jar:2.13.0:compile
++- com.google.guava:guava:jar:32.0.1-jre:compile
 |  +- com.google.guava:failureaccess:jar:1.0.1:compile
 |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
-|  +- org.checkerframework:checker-qual:jar:3.29.0:compile
-|  +- com.google.errorprone:error_prone_annotations:jar:2.10.0:compile
-|  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
-+- org.glassfish.jersey.core:jersey-client:jar:2.33:compile
-+- org.glassfish.jersey.media:jersey-media-json-jackson:jar:2.33:compile
-|  +- org.glassfish.jersey.ext:jersey-entity-filtering:jar:2.33:compile
-|  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.10.5:compile
-+- org.glassfish.jersey.media:jersey-media-multipart:jar:2.33:compile
+|  +- com.google.errorprone:error_prone_annotations:jar:2.20.0:compile
+|  \- com.google.j2objc:j2objc-annotations:jar:2.8:compile
++- org.glassfish.jersey.core:jersey-client:jar:3.0.10:compile
++- org.glassfish.jersey.media:jersey-media-json-jackson:jar:3.0.10:compile
+|  +- org.glassfish.jersey.ext:jersey-entity-filtering:jar:3.0.10:compile
+|  \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.15.2:compile
++- org.glassfish.jersey.media:jersey-media-multipart:jar:3.0.10:compile
 |  \- org.jvnet.mimepull:mimepull:jar:1.9.13:compile
-+- org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.33:compile
++- org.glassfish.jersey.connectors:jersey-apache-connector:jar:3.0.10:compile
 |  \- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
 |     +- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
+|     +- commons-logging:commons-logging:jar:1.2:compile
 |     \- commons-codec:commons-codec:jar:1.15:compile
-+- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.33:compile
-+- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
-+- com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:compile
-|  \- com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
++- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:3.0.10:compile
++- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
++- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
+|  \- com.fasterxml.jackson.core:jackson-core:jar:2.15.2:compile
 +- xerces:xercesImpl:jar:2.12.2:compile
 |  \- xml-apis:xml-apis:jar:1.4.01:compile
-+- org.yaml:snakeyaml:jar:1.33:compile
-+- org.testng:testng:jar:7.5:test
-|  +- com.beust:jcommander:jar:1.78:test
-|  \- org.webjars:jquery:jar:3.5.1:test
-+- org.mockito:mockito-core:jar:4.11.0:test
-|  +- net.bytebuddy:byte-buddy:jar:1.12.22:test
-|  +- net.bytebuddy:byte-buddy-agent:jar:1.12.19:test
++- org.yaml:snakeyaml:jar:2.0:compile
++- org.testng:testng:jar:7.8.0:test
+|  +- com.beust:jcommander:jar:1.82:test
+|  \- org.webjars:jquery:jar:3.6.1:test
++- org.mockito:mockito-core:jar:5.2.0:test
+|  +- net.bytebuddy:byte-buddy:jar:1.14.5:test
+|  +- net.bytebuddy:byte-buddy-agent:jar:1.14.1:test
 |  \- org.objenesis:objenesis:jar:3.3:test
-+- org.mockito:mockito-testng:jar:0.4.31:test
++- org.mockito:mockito-testng:jar:0.5.0:test
 +- org.assertj:assertj-core:jar:3.24.2:test
 \- com.google.code.findbugs:annotations:jar:3.0.1u2:provided
-   \- net.jcip:jcip-annotations:jar:1.0:provided
+   +- net.jcip:jcip-annotations:jar:1.0:provided
+   \- com.google.code.findbugs:jsr305:jar:3.0.1:compile

--- a/nlp-service/nlp.cmd
+++ b/nlp-service/nlp.cmd
@@ -1,5 +1,5 @@
 cd target
 del nlp-logs\*.log
 del *-shaded.jar
-for %%i in (nlp-service-*.jar) do java -Ddw.server.applicationConnectors[0].port=8060 -Ddw.swagger.enabled=true -Dfile.encoding=UTF-8 -jar %%i server nlp-default-config.yml
+for %%i in (nlp-service-*.jar) do java -Ddw.server.applicationConnectors[0].port=8060 -Ddw.server.adminConnectors[0].port=8061 -Ddw.swagger.enabled=true -Dfile.encoding=UTF-8 -jar %%i server nlp-default-config.yml
 cd ..

--- a/nlp-service/nlp.sh
+++ b/nlp-service/nlp.sh
@@ -2,6 +2,6 @@ cd target
 rm -f nlp-logs\*.log
 rm -f *-shaded.jar
 for nlpjar in nlp-service-*.jar; do 
-  java -Ddw.server.applicationConnectors[0].port=8060 -Ddw.swagger.enabled=true -Dfile.encoding=UTF-8 -jar "$nlpjar" server nlp-default-config.yml
+  java -Ddw.server.applicationConnectors[0].port=8060 -Ddw.server.adminConnectors[0].port=8061 -Ddw.swagger.enabled=true -Dfile.encoding=UTF-8 -jar "$nlpjar" server nlp-default-config.yml
 done
 cd ..

--- a/nlp-service/pom.xml
+++ b/nlp-service/pom.xml
@@ -8,22 +8,22 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
 
     <!-- Third-party dependencies -->
-    <stanford-corenlp.version>4.5.3</stanford-corenlp.version>
-    <dropwizard.version>2.0.35</dropwizard.version>
-    <dropwizard-swagger.version>2.0.0-1</dropwizard-swagger.version>
-    <swagger-annotations.version>2.1.12</swagger-annotations.version>
+    <stanford-corenlp.version>4.5.4</stanford-corenlp.version>
+    <dropwizard.version>4.0.1</dropwizard.version>
+    <dropwizard-swagger.version>4.0.0-1</dropwizard-swagger.version>
+    <swagger-annotations.version>2.2.9</swagger-annotations.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.13.0</commons-io.version>
     <xercesImpl.version>2.12.2</xercesImpl.version>
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
 
     <!-- Testing -->
-    <mockito.version>4.11.0</mockito.version>
-    <testng.version>7.5</testng.version>
-    <mockito-testng.version>0.4.31</mockito-testng.version>
+    <mockito.version>5.2.0</mockito.version>
+    <testng.version>7.8.0</testng.version>
+    <mockito-testng.version>0.5.0</mockito-testng.version>
     <assertj-core.version>3.24.2</assertj-core.version>
 
     <!-- Code metrics etc -->
@@ -32,16 +32,16 @@
     <!-- Maven plugins -->
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
-    <maven-release-plugin.version>3.0.0</maven-release-plugin.version>
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-    <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
+    <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
     <ossindex-maven-plugin.version>3.2.0</ossindex-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
+    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
 
     <!-- Maven enforcer versions -->
     <required-maven.version>3.8</required-maven.version>
@@ -287,17 +287,26 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <argLine>${jacocoSurefireArgLine} -Dfile.encoding=UTF-8</argLine>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>
@@ -316,6 +325,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>

--- a/nlp-service/src/main/java/com/veritas/nlp/models/NlpMatch.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/models/NlpMatch.java
@@ -1,8 +1,8 @@
 package com.veritas.nlp.models;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@ApiModel(description = ModelStrings.CONTENT_MATCH_DESCRIPTION)
+@Schema(description = ModelStrings.CONTENT_MATCH_DESCRIPTION)
 public class NlpMatch {
     private long offset;
     private long length;

--- a/nlp-service/src/main/java/com/veritas/nlp/models/NlpMatchCollection.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/models/NlpMatchCollection.java
@@ -1,6 +1,6 @@
 package com.veritas.nlp.models;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +17,7 @@ public class NlpMatchCollection {
         this.matches = matches;
     }
 
-    @ApiModelProperty(value = ModelStrings.NLP_MATCHES_TOTAL)
+    @Schema(description = ModelStrings.NLP_MATCHES_TOTAL)
     public int getTotal() {
         return total;
     }

--- a/nlp-service/src/main/java/com/veritas/nlp/ner/StreamingNerRecognizer.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/ner/StreamingNerRecognizer.java
@@ -39,8 +39,15 @@ public class StreamingNerRecognizer {
         // NOTE: BOMInputStream will detect the charset from the BOM and then (by default) skip the BOM.
         // WARNING! BOMInputStream sorts the supplied array of BOMs, so DO NOT pass in a static array, or you may
         //          hit a nasty race condition with multiple threads!
-        BOMInputStream bomInputStream = new BOMInputStream(textStream, ByteOrderMark.UTF_32LE, ByteOrderMark.UTF_32BE,
-                ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_8);
+        BOMInputStream bomInputStream = BOMInputStream.builder()
+                .setInputStream(textStream)
+                .setByteOrderMarks(
+                        ByteOrderMark.UTF_32LE,
+                        ByteOrderMark.UTF_32BE,
+                        ByteOrderMark.UTF_16LE,
+                        ByteOrderMark.UTF_16BE,
+                        ByteOrderMark.UTF_8)
+                .get();
         String charset = bomInputStream.getBOMCharsetName() != null ? bomInputStream.getBOMCharsetName() : StandardCharsets.UTF_8.name();
 
         InputStreamReader inputStreamReader = new InputStreamReader(bomInputStream, charset);

--- a/nlp-service/src/main/java/com/veritas/nlp/resources/ApiRoot.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/resources/ApiRoot.java
@@ -3,12 +3,10 @@ package com.veritas.nlp.resources;
 import io.federecio.dropwizard.swagger.SwaggerOAuth2Configuration;
 import io.federecio.dropwizard.swagger.SwaggerResource;
 import io.federecio.dropwizard.swagger.SwaggerViewConfiguration;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.HEAD;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nlp-service/src/main/java/com/veritas/nlp/resources/NerResource.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/resources/NerResource.java
@@ -1,30 +1,37 @@
 package com.veritas.nlp.resources;
 
-import java.io.*;
-import java.time.Duration;
-import java.util.*;
-
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.jaxrs.annotation.JacksonFeatures;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import com.fasterxml.jackson.jakarta.rs.annotation.JacksonFeatures;
 import com.veritas.nlp.models.ErrorResponse;
 import com.veritas.nlp.models.NerResult;
 import com.veritas.nlp.models.NlpTagSet;
 import com.veritas.nlp.models.NlpTagType;
 import com.veritas.nlp.ner.StreamingNerRecognizer;
 import com.veritas.nlp.service.NlpServiceSettings;
-import io.swagger.annotations.*;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
 
 @Path("/v1")
-@Api(value = "Named Entity Recognition")
+@Tag(name = "Named Entity Recognition")
 public class NerResource {
     private final NlpServiceSettings settings;
 
@@ -36,31 +43,45 @@ public class NerResource {
     @Path("names")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(
-            value = "Extract named entities from the supplied text",
-            response = NerResult.class,
-            responseContainer = "Map",
-            notes = ResourceStrings.ENTITIES_OPERATION_NOTES)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Success", response = NerResult.class),
-            @ApiResponse(code = 400, message = "Bad request", response = ErrorResponse.class),
-            @ApiResponse(code = 401, message = "Unauthorized", response = ErrorResponse.class),
-            @ApiResponse(code = 403, message = "Forbidden", response = ErrorResponse.class),
-            @ApiResponse(code = 404, message = "Not found", response = ErrorResponse.class),
-            @ApiResponse(code = 422, message = "Unprocessable entity", response = ErrorResponse.class),
-            @ApiResponse(code = 500, message = "Internal server error", response = ErrorResponse.class),
-            @ApiResponse(code = 503, message = "Service unavailable", response = ErrorResponse.class)
-    })
+    @Operation(
+            summary = "Extract named entities from the supplied text",
+            description = ResourceStrings.ENTITIES_OPERATION_NOTES,
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "Success",
+                            content = @Content(schema = @Schema(implementation = NerResult.class))),
+                    @ApiResponse(responseCode = "400",
+                            description = "Bad request",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401",
+                            description = "Unauthorized",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403",
+                            description = "Forbidden",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404",
+                            description = "Not found",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "422",
+                            description = "Unprocessable entity",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500",
+                            description = "Internal server error",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "503",
+                            description = "Service unavailable",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
     @JacksonFeatures(serializationEnable = {SerializationFeature.INDENT_OUTPUT})
     public Response extractEntities(
-            @ApiParam(value = ResourceStrings.ENTITIES_DOCUMENT) @FormDataParam("file") InputStream documentStream,
+            @Parameter(description = ResourceStrings.ENTITIES_DOCUMENT) @FormDataParam("file") InputStream documentStream,
             @FormDataParam("file") FormDataContentDisposition fileMetaData,
-            @ApiParam(value = ResourceStrings.ENTITIES_TYPES) @QueryParam("type") Set<NlpTagType> types,
+            @Parameter(description = ResourceStrings.ENTITIES_TYPES) @QueryParam("type") Set<NlpTagType> types,
             @DefaultValue("300") @QueryParam("timeoutSeconds") int timeoutSeconds,
-            @ApiParam(value = ResourceStrings.ENTITIES_MIN_CONFIDENCE_PERCENTAGE) @DefaultValue("90") @QueryParam("minConfidencePercentage") int minConfidencePercentage,
-            @ApiParam(value = ResourceStrings.ENTITIES_INCLUDE_MATCHES) @QueryParam("includeMatches") boolean includeMatches,
-            @ApiParam(value = ResourceStrings.ENTITIES_MAX_CONTENT_MATCHES) @QueryParam("maxContentMatches") Integer maxContentMatches
-            ) throws Exception {
+            @Parameter(description = ResourceStrings.ENTITIES_MIN_CONFIDENCE_PERCENTAGE) @DefaultValue("90") @QueryParam("minConfidencePercentage") int minConfidencePercentage,
+            @Parameter(description = ResourceStrings.ENTITIES_INCLUDE_MATCHES) @QueryParam("includeMatches") boolean includeMatches,
+            @Parameter(description = ResourceStrings.ENTITIES_MAX_CONTENT_MATCHES) @QueryParam("maxContentMatches") Integer maxContentMatches
+    ) throws Exception {
 
         NlpRequestParams params = new NlpRequestParams()
             .setIncludeMatches(includeMatches)

--- a/nlp-service/src/main/java/com/veritas/nlp/resources/ResourceExceptionMapper.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/resources/ResourceExceptionMapper.java
@@ -1,22 +1,22 @@
 package com.veritas.nlp.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.veritas.nlp.ner.NerException;
 import com.veritas.nlp.models.ErrorResponse;
+import com.veritas.nlp.ner.NerException;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status.Family;
+import jakarta.ws.rs.core.Response.StatusType;
+import jakarta.ws.rs.ext.ExceptionMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.Response.StatusType;
-import javax.ws.rs.ext.ExceptionMapper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;

--- a/nlp-service/src/main/java/com/veritas/nlp/service/LoggingFilter.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/service/LoggingFilter.java
@@ -1,13 +1,13 @@
 package com.veritas.nlp.service;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import org.slf4j.MDC;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import java.io.IOException;
 
 public class LoggingFilter implements Filter {

--- a/nlp-service/src/main/java/com/veritas/nlp/service/NlpConfiguration.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/service/NlpConfiguration.java
@@ -1,8 +1,7 @@
 package com.veritas.nlp.service;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 
 public class NlpConfiguration extends Configuration {

--- a/nlp-service/src/main/java/com/veritas/nlp/service/NlpHealthCheck.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/service/NlpHealthCheck.java
@@ -3,11 +3,11 @@ package com.veritas.nlp.service;
 import com.codahale.metrics.health.HealthCheck;
 import com.veritas.nlp.models.NlpTagType;
 import com.veritas.nlp.resources.NerResource;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;

--- a/nlp-service/src/main/java/com/veritas/nlp/service/NlpMicroService.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/service/NlpMicroService.java
@@ -1,14 +1,15 @@
 package com.veritas.nlp.service;
 
-import java.lang.management.ManagementFactory;
-
+import com.veritas.nlp.resources.ApiRoot;
 import com.veritas.nlp.resources.NerResource;
 import com.veritas.nlp.resources.ResourceExceptionMapper;
-import io.dropwizard.Application;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-
-import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.core.Application;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.lifecycle.Managed;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -17,12 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import com.veritas.nlp.resources.ApiRoot;
-
-import io.dropwizard.lifecycle.Managed;
-import io.dropwizard.setup.Environment;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.lang.management.ManagementFactory;
 
 public class NlpMicroService extends Application<NlpConfiguration> {
     private static final Logger LOG = LoggerFactory.getLogger(NlpMicroService.class);

--- a/nlp-service/src/main/java/com/veritas/nlp/service/NlpSwaggerBundle.java
+++ b/nlp-service/src/main/java/com/veritas/nlp/service/NlpSwaggerBundle.java
@@ -1,13 +1,11 @@
 package com.veritas.nlp.service;
 
-import io.dropwizard.setup.Environment;
+import com.veritas.nlp.resources.ApiRoot;
+import io.dropwizard.core.setup.Environment;
 import io.federecio.dropwizard.swagger.ConfigurationHelper;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-
 import org.apache.commons.lang3.StringUtils;
-
-import com.veritas.nlp.resources.ApiRoot;
 
 class NlpSwaggerBundle extends SwaggerBundle<NlpConfiguration> {
     @Override

--- a/nlp-service/src/test/java/com/veritas/nlp/service/HttpClientBuilder.java
+++ b/nlp-service/src/test/java/com/veritas/nlp/service/HttpClientBuilder.java
@@ -1,17 +1,16 @@
 package com.veritas.nlp.service;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import io.dropwizard.util.Duration;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 
 class HttpClientBuilder {
     private static final int CONNECT_TIMEOUT_MS = 60000;
@@ -22,13 +21,13 @@ class HttpClientBuilder {
                 .property(ClientProperties.CONNECT_TIMEOUT, CONNECT_TIMEOUT_MS)
                 .property(ClientProperties.READ_TIMEOUT, (int)timeout.toMilliseconds())
                 // Request bodies can be very large so use chunked request entity processing
-                // with the down side that requests are not repeatable
+                // with the downside that requests are not repeatable
                 .property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.CHUNKED)
                 .property(ClientProperties.CHUNKED_ENCODING_SIZE, 64 * 1024);
 
         return ClientBuilder.newClient(clientConfig)
                 .register(JacksonFeature.class)
                 .register(MultiPartFeature.class)
-                .register(new JacksonJaxbJsonProvider().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+                .register(new JacksonJsonProvider().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
     }
 }

--- a/nlp-service/src/test/java/com/veritas/nlp/service/NlpHealthCheckTest.java
+++ b/nlp-service/src/test/java/com/veritas/nlp/service/NlpHealthCheckTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.health.HealthCheck;
 import com.veritas.nlp.models.NlpTagType;
 import com.veritas.nlp.ner.NerException;
 import com.veritas.nlp.resources.NerResource;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.jetty.http.HttpStatus;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -13,7 +14,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.core.Response;
 import java.io.InputStream;
 import java.util.EnumSet;
 

--- a/nlp-service/src/test/java/com/veritas/nlp/service/NlpServiceIT.java
+++ b/nlp-service/src/test/java/com/veritas/nlp/service/NlpServiceIT.java
@@ -1,9 +1,13 @@
 package com.veritas.nlp.service;
 
 import com.veritas.nlp.models.NerResult;
-import com.veritas.nlp.models.NlpMatch;
 import com.veritas.nlp.models.NlpTagSet;
 import com.veritas.nlp.models.NlpTagType;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
@@ -11,18 +15,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;

--- a/nlp-service/src/test/java/com/veritas/nlp/service/TestNlpService.java
+++ b/nlp-service/src/test/java/com/veritas/nlp/service/TestNlpService.java
@@ -3,10 +3,10 @@ package com.veritas.nlp.service;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.util.Duration;
+import jakarta.ws.rs.client.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.client.Client;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
-- Replaced javax package with jakarta package in all required places. Same with all swagger annotations which are modified to use v3. 
-- Also upgraded multiple Maven plugins and testing dependencies. 
-- Java version upgraded to 11 and used release configuration parameter for maven compiler plugin instead of source & target. -- -- Removed use of deprecated classes and methods.
-- Explicitly set TestNG runner for surefire and failsafe plugins. 
-- Updated dependencies.txt and dependencies_tree.txt.